### PR TITLE
update fork code avoid of locking problem

### DIFF
--- a/COMAKE
+++ b/COMAKE
@@ -11,7 +11,6 @@ CopyUsingHardLink(True)
 #ENABLE_MULTI_LIBS(True)
 
 #C预处理器参数.
-#CPPFLAGS('-D_GNU_SOURCE -D__STDC_LIMIT_MACROS -DVERSION=\\\"1.9.8.7\\\" -DAGENT_WORK_DIR=\\\"test\/\\\"')
 CPPFLAGS('-D_GNU_SOURCE -D__STDC_LIMIT_MACROS -DVERSION=\\\"1.9.8.7\\\"')
 #为32位目标编译指定额外的预处理参数
 #CPPFLAGS_32('-D_XOPEN_SOURE=500')

--- a/src/agent/agent_impl.cc
+++ b/src/agent/agent_impl.cc
@@ -63,66 +63,50 @@ void AgentImpl::OpenProcess(const std::string& task_name,
     close(fd);
 
     LOG(INFO, "Fork to Run %s", task_name.c_str());
+    std::string root_path = FLAGS_agent_work_dir;
+
+    // do prepare, NOTE, root_path should be unqic
+    std::string task_stdout = root_path + "./stdout";
+    std::string task_stderr = root_path + "./stderr"; 
+    int stdout_fd = open(task_stdout.c_str(), O_CREAT | O_TRUNC | O_WRONLY, S_IRWXU);
+    int stderr_fd = open(task_stdout.c_str(), O_CREAT | O_TRUNC | O_WRONLY, S_IRWXU);
+
+    int cur_pid = getpid();
+    std::vector<int> fds;
+    common::util::GetProcessFdList(cur_pid, fds);
+    // put last two fd for child process, dup
+
     pid_t pid = fork();
     if (pid != 0) {
+        close(stdout_fd);
+        close(stderr_fd);
         return;
     }
-    std::string root_path = FLAGS_agent_work_dir;
-    RunInnerChildProcess(root_path, cmd_line);
-    return;
-}
 
-void AgentImpl::RunInnerChildProcess(const std::string& root_path,
-                                     const std::string& cmd_line) {
-    // do some prepare
-    // 1. change stdout/stderr
-    std::string task_stdout = root_path + "./stdout";
-    std::string task_stderr = root_path + "./stderr";
-    int stdout_fd = open(task_stdout.c_str(), O_CREAT | O_TRUNC | O_WRONLY, S_IRWXU);
-    int stderr_fd = open(task_stderr.c_str(), O_CREAT | O_TRUNC | O_WRONLY, S_IRWXU);
-    dup2(stdout_fd, STDOUT_FILENO);
-    dup2(stderr_fd, STDERR_FILENO);
-    common::util::CloseOnExec(stdout_fd);
-    common::util::CloseOnExec(stderr_fd);
+    // do in child process
+    // NOTE if dup2 will return errno == EINTR?  
+    while (dup2(stdout_fd, STDOUT_FILENO) == -1 && errno == EINTR) {}
+    while (dup2(stderr_fd, STDERR_FILENO) == -1 && errno == EINTR) {}
 
-    // 2. change PWD
-    //std::map<std::string, std::string> env;
-    //common::util::GetEnviron(env);
-    //std::map<std::string, std::string>::iterator it = env.find("PWD");
-    //if (it != env.end()) {
-    //    it->second = root_path;     
-    //}
-    //
-    //it = env.begin();
-    //const char* envp[env.size() + 1];
-    //for (int i = 0;it != env.end(); ++i, ++it) {
-    //    envp[i] = it->second.c_str();
-    //}
-    //envp[env.size()] = NULL;
-
-    //if (setenv("PWD", root_path.c_str(), 1) != 0) {
-    //    LOG(INFO, "set pwd failed %d %s", errno, strerror(errno));     
-    //}
-
-    // 3. close on exec
-    int pid = getpid();
-    std::vector<int> fds;
-    common::util::GetProcessFdList(pid, fds);
-    for (size_t i = 3; i < fds.size(); i++) {
-        common::util::CloseOnExec(fds[i]);
+    for (size_t i = 0; i < fds.size(); i++) {
+        if (fds[i] == STDOUT_FILENO 
+                || fds[i] == STDERR_FILENO 
+                || fds[i] == STDIN_FILENO) {
+            // do not deal with std input/output
+            continue; 
+        } 
+        close(fds[i]);
     }
+    
     chdir(root_path.c_str());
-
-    LOG(INFO, "RunInnerChildProcess task %s", cmd_line.c_str());
 
     int ret = execl("/bin/sh", "sh", "-c", cmd_line.c_str(), NULL);
     if (ret != 0) {
         LOG(INFO, "exec failed %d %s", errno, strerror(errno));
     }
-
-    /* Exit the child process if execl fails */
     assert(0);
     _exit(127);
+    return;
 }
 
 void AgentImpl::RunTask(::google::protobuf::RpcController* controller,

--- a/src/agent/agent_impl.h
+++ b/src/agent/agent_impl.h
@@ -33,8 +33,6 @@ private:
     void OpenProcess(const std::string& task_name,
                      const std::string& task_raw,
                      const std::string& cmd_line);
-    void RunInnerChildProcess(const std::string& root_path, 
-                              const std::string& cmd_line);
 private:
     common::ThreadPool thread_pool_;
     RpcClient* rpc_client_;

--- a/src/flags.cc
+++ b/src/flags.cc
@@ -9,12 +9,7 @@ std::string FLAGS_master_port = "8101";
 std::string FLAGS_agent_port = "8102";
 std::string FLAGS_master_addr = "localhost:" + FLAGS_master_port;
 
-#ifdef AGENT_WORK_DIR
-const char* work_dir = AGENT_WORK_DIR;
-std::string FLAGS_agent_work_dir(work_dir);
-#else 
-std::string FLAGS_agent_work_dir;
-#endif
+std::string FLAGS_agent_work_dir = ".";
 
 
 /* vim: set expandtab ts=4 sw=4 sts=4 tw=100: */


### PR DESCRIPTION
把部分逻辑从子进程移到父进程，防止系统调用锁问题，保留的操作基本上是async-safe的接口，保证不会应为主进程的内存状态在fork的时候影响到子进程接口的调用