### PR TITLE
support update job

### DIFF
--- a/src/agent/pod_manager.cc
+++ b/src/agent/pod_manager.cc
@@ -272,6 +272,8 @@ int PodManager::CheckPod(const std::string& pod_id) {
     }
     pod_info.pod_status.mutable_resource_used()->set_millicores(millicores);
     pod_info.pod_status.mutable_resource_used()->set_memory(memory_used);
+    std::string version = pod_info.pod_desc.version();
+    pod_info.pod_status.set_version(version);
     switch (pod_state) {
         case kTaskPending : 
         pod_info.pod_status.set_state(kPodPending);

--- a/src/flags.cc
+++ b/src/flags.cc
@@ -20,6 +20,7 @@ DEFINE_string(master_lock_path, "/master_lock", "master lock name on nexus");
 DEFINE_string(master_path, "/master", "master path on nexus");
 DEFINE_string(jobs_store_path, "/jobs", "");
 DEFINE_string(labels_store_path, "/labels", "");
+DEFINE_int32(max_need_update_job_size, 10, "the max size of need update job size ");
 DEFINE_int32(max_scale_down_size, 10, "the max size of scale down jobs that schedule fetches");
 DEFINE_int32(max_scale_up_size, 10, "the max size of scale up jobs that schedule fetches");
 DEFINE_int32(master_pending_job_wait_timeout, 1000, "the timeout that master pending scheduler request");

--- a/src/master/job_manager.cc
+++ b/src/master/job_manager.cc
@@ -198,7 +198,6 @@ bool JobManager::HandleUpdateJob(const JobDescriptor& desc, Job* job,
     if (replica_change == NULL || pod_desc_change == NULL) {
         return false;
     }
-    bool has_change = false;
     *pod_desc_change = false;
     *replica_change = false;
     if (desc.pod().version() != job->latest_version) {
@@ -338,7 +337,7 @@ void JobManager::ProcessUpdateJob(JobInfoList* need_update_jobs,
     for (; jobid_it != need_update_jobs_.end(); ++jobid_it) {
         std::map<JobId, Job*>::iterator job_it = jobs_.find(*jobid_it);
         if (job_it == jobs_.end()) {
-            should_rm_from_update.insert(*job_it);
+            should_rm_from_update.insert(*jobid_it);
             continue;
         }
         Job* job = job_it->second;

--- a/src/master/job_manager.h
+++ b/src/master/job_manager.h
@@ -107,6 +107,8 @@ private:
                           int32_t max_scale_down_size);
     void ProcessScaleUp(JobInfoList* scale_up_pods,
                         int32_t max_scale_up_size);
+    void ProcessUpdateJob(JobInfoList* need_update_jobs,
+                         int32_t max_need_update_job_size);
     void BuildPodFsm();
     bool HandleCleanPod(PodStatus* pod, Job* job);
     bool HandlePendingToRunning(PodStatus* pod, Job* job);
@@ -125,6 +127,9 @@ private:
     bool SaveToNexus(const Job* job);
     bool SaveLabelToNexus(const LabelCell& label_cell);
     bool DeleteFromNexus(const JobId& jobid);
+
+    bool HandleUpdateJob(const JobDescriptor& desc, Job* job, 
+                         bool* replica_change, bool* pod_desc_change);
 private:
     std::map<JobId, Job*> jobs_;
     typedef std::map<JobId, std::map<PodId, PodStatus*> > PodMap;

--- a/src/master/job_manager.h
+++ b/src/master/job_manager.h
@@ -28,14 +28,17 @@ typedef google::protobuf::RepeatedPtrField<baidu::galaxy::AgentInfo> AgentInfoLi
 typedef google::protobuf::RepeatedPtrField<baidu::galaxy::JobOverview> JobOverviewList;
 typedef google::protobuf::RepeatedPtrField<baidu::galaxy::DiffVersion> DiffVersionList;
 typedef google::protobuf::RepeatedPtrField<std::string> StringList;
+typedef std::string Version;
 
 struct Job {
     JobState state_;
     std::map<PodId, PodStatus*> pods_;
     JobDescriptor desc_;
     JobId id_;
+    std::map<Version, PodDescriptor> pod_desc_;
+    JobUpdateState update_state_;
+    Version latest_version;
 };
-
 
 class JobManager {
 public:
@@ -50,6 +53,8 @@ public:
                         int32_t max_scale_up_size,
                         JobInfoList* scale_down_pods,
                         int32_t max_scale_down_size,
+                        JobInfoList* need_update_jobs,
+                        int32_t max_need_update_job_size,
                         ::google::protobuf::Closure* done);
     Status Propose(const ScheduleInfo& sche_info);
     void GetAgentsInfo(AgentInfoList* agents_info);
@@ -127,7 +132,8 @@ private:
     std::set<JobId> scale_up_jobs_;
     // all jobs that need scale down
     std::set<JobId> scale_down_jobs_;
-
+    // all jobs that need update
+    std::set<JobId> need_update_jobs_;
     std::map<AgentAddr, PodMap> pods_on_agent_;
     std::map<AgentAddr, AgentInfo*> agents_;
     std::map<AgentAddr, int64_t> agent_timer_;

--- a/src/master/master_impl.cc
+++ b/src/master/master_impl.cc
@@ -213,6 +213,7 @@ void MasterImpl::GetPendingJobs(::google::protobuf::RpcController* /*controller*
                                 ::google::protobuf::Closure* done) {
     int32_t max_scale_up_size = FLAGS_max_scale_up_size;
     int32_t max_scale_down_size = FLAGS_max_scale_down_size;
+    int32_t max_need_update_job_size = 0;
     if (request->has_max_scale_up_size() 
         && request->max_scale_up_size() > 0) {
         max_scale_up_size = request->max_scale_up_size();
@@ -225,7 +226,10 @@ void MasterImpl::GetPendingJobs(::google::protobuf::RpcController* /*controller*
     job_manager_.GetPendingPods(response->mutable_scale_up_jobs(),
                                 max_scale_up_size,
                                 response->mutable_scale_down_jobs(),
-                                max_scale_down_size, done);
+                                max_scale_down_size,
+                                response->mutable_need_update_jobs(),
+                                max_need_update_job_size,
+                                done);
 }
 
 void MasterImpl::GetResourceSnapshot(::google::protobuf::RpcController* /*controller*/,

--- a/src/master/master_impl.cc
+++ b/src/master/master_impl.cc
@@ -14,6 +14,7 @@ DECLARE_string(jobs_store_path);
 DECLARE_string(labels_store_path);
 DECLARE_int32(max_scale_down_size);
 DECLARE_int32(max_scale_up_size);
+DECLARE_int32(max_need_update_job_size);
 
 namespace baidu {
 namespace galaxy {
@@ -213,7 +214,7 @@ void MasterImpl::GetPendingJobs(::google::protobuf::RpcController* /*controller*
                                 ::google::protobuf::Closure* done) {
     int32_t max_scale_up_size = FLAGS_max_scale_up_size;
     int32_t max_scale_down_size = FLAGS_max_scale_down_size;
-    int32_t max_need_update_job_size = 0;
+    int32_t max_need_update_job_size = FLAGS_max_need_update_job_size;
     if (request->has_max_scale_up_size() 
         && request->max_scale_up_size() > 0) {
         max_scale_up_size = request->max_scale_up_size();
@@ -221,6 +222,10 @@ void MasterImpl::GetPendingJobs(::google::protobuf::RpcController* /*controller*
     if (request->has_max_scale_down_size()
         && request->max_scale_down_size() > 0) {
         max_scale_down_size = request->max_scale_down_size();
+    }
+    if (request->has_max_need_update_job_size()
+        && request->max_need_update_job_size() > 0) {
+        max_need_update_job_size = request->max_need_update_job_size();
     }
     response->set_status(kOk);
     job_manager_.GetPendingPods(response->mutable_scale_up_jobs(),

--- a/src/master/master_util.cc
+++ b/src/master/master_util.cc
@@ -62,11 +62,10 @@ std::string MasterUtil::SelfEndpoint() {
 void MasterUtil::TraceJobDesc(const JobDescriptor& job_desc) {
     LOG(INFO, "job descriptor: \"%s\", "
               "replica:%d, "
-              "deploy_step:%d, version:\"%s\"",
+              "deploy_step:%d",
               job_desc.name().c_str(),
               job_desc.replica(),
-              job_desc.deploy_step(),
-              job_desc.version().c_str()
+              job_desc.deploy_step()
     );
     for (int i = 0; i < job_desc.pod().tasks_size(); i++) {
         const TaskDescriptor& task_desc = job_desc.pod().tasks(i);

--- a/src/proto/galaxy.proto
+++ b/src/proto/galaxy.proto
@@ -92,6 +92,7 @@ message PodDescriptor {
     optional Resource requirement = 2;
     optional bool pin_on_agent = 3 [default = false];
     repeated string labels = 4;
+    optional string version = 5;
 }
 
 message TaskStatus {
@@ -108,9 +109,9 @@ message PodStatus {
     repeated TaskStatus status = 3; 
     optional Resource resource_used = 4;
     optional string endpoint = 5;
-    optional string version = 6;
     optional PodState state = 7;
     optional PodStage stage = 8;
+    optional string version = 9;
 }
 
 message AgentInfo {

--- a/src/proto/master.proto
+++ b/src/proto/master.proto
@@ -149,7 +149,7 @@ message HeartBeatResponse {
 message GetPendingJobsRequest {
     optional int32 max_scale_down_size = 4;
     optional int32 max_scale_up_size = 5;
-
+    optional int32 max_need_update_job_size = 6;
 }
 
 message GetPendingJobsResponse {

--- a/src/proto/master.proto
+++ b/src/proto/master.proto
@@ -20,8 +20,12 @@ enum JobPriority {
 
 enum JobState {
     kJobNormal = 0;
-    kJobSuspend = 1;
     kJobTerminated = 2;
+}
+
+enum JobUpdateState {
+    kUpdateNormal = 0;
+    kUpdateSuspend = 1;
 }
 
 enum ScheduleAction {
@@ -39,7 +43,6 @@ message JobDescriptor {
     repeated string labels = 6;
     optional int32 replica = 7;
     optional int32 deploy_step = 8;
-    optional string version = 9;
 }
 
 message JobInfo {
@@ -47,6 +50,11 @@ message JobInfo {
     optional JobDescriptor desc = 2;
     repeated PodStatus pods = 3;
     optional JobState state = 4;
+    optional JobUpdateState update_state = 5;
+    // per version per PodDescriptor
+    repeated PodDescriptor pod_descs = 6;
+    // pod latest pod descriptor
+    optional string latest_version = 7;
 }
 
 message ScheduleInfo {
@@ -147,7 +155,8 @@ message GetPendingJobsRequest {
 message GetPendingJobsResponse {
     repeated JobInfo scale_up_jobs = 1;
     repeated JobInfo scale_down_jobs = 2;
-    optional Status status = 3;
+    repeated JobInfo need_update_jobs = 3;
+    optional Status status = 4;
 }
 
 message DiffVersion {

--- a/src/scheduler/scheduler.h
+++ b/src/scheduler/scheduler.h
@@ -98,6 +98,8 @@ public:
     int32_t ScheduleScaleDown(std::vector<JobInfo*>& reducing_jobs,
                      std::vector<ScheduleInfo*>* propose);
 
+    int32_t ScheduleUpdate(std::vector<JobInfo*>& update_jobs,
+                           std::vector<ScheduleInfo*>* propose);
     // 从master同步资源数据
     int32_t SyncResources(const GetResourceSnapshotResponse* response);
 
@@ -115,8 +117,9 @@ private:
                 std::vector<PodScaleDownCell*>* reducing_pods);
 
     int32_t ChooseResourse(std::vector<AgentInfoExtend*>* resources_to_alloc);
-
-
+    
+    void HandleJobUpdate(JobInfo* job_info, 
+                        std::vector<ScheduleInfo*>* propose);
     template<class T>
     void Shuffle(std::vector<T>& list) {
         for (size_t i = list.size(); i > 1; i--) {

--- a/src/scheduler/scheduler_io.cc
+++ b/src/scheduler/scheduler_io.cc
@@ -90,7 +90,12 @@ void SchedulerIO::SyncPendingJobCallBack(const GetPendingJobsRequest* request,
     for (int i = 0; i < response_ptr->scale_down_jobs_size(); i++) {
         scale_down_jobs.push_back(response_ptr->mutable_scale_down_jobs(i));
     }
+    std::vector<JobInfo*> need_update_jobs;
+    for(int i = 0; i < response_ptr->need_update_jobs_size(); i++) {
+        need_update_jobs.push_back(response_ptr->mutable_need_update_jobs(i));
+    }
     std::vector<ScheduleInfo*> propose;
+
     int32_t status = scheduler_.ScheduleScaleUp(scale_up_jobs, &propose);
     if (status < 0) {
         LOG(WARNING, "fail to schedule scale up ");
@@ -101,7 +106,12 @@ void SchedulerIO::SyncPendingJobCallBack(const GetPendingJobsRequest* request,
     if (status < 0) {
         LOG(WARNING, "fail to schedule scale down ");
         CleanPropse(propose);
-    } 
+    }
+    status = scheduler_.ScheduleUpdate(need_update_jobs, &propose);
+    if (status != 0) {
+        LOG(WARNING, "fail to schedule scale down ");
+        CleanPropse(propose);
+    }
     if (propose.size() > 0) {
         ProposeRequest pro_request;
         ProposeResponse pro_response;


### PR DESCRIPTION
master 更新逻辑，目前代码逻辑实现是基于#202 pr实现，目前还差调度器逻辑
* 更新调度逻辑负责保持pod 描述信息更新，并根据并发kill pod,
* 实例调度逻辑负责保持pod实例数,当实例数降低时，重新调度